### PR TITLE
Move main.go into run sub-package

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,4 +1,4 @@
-package main
+package unicorn
 
 import (
 	"github.com/paketo-buildpacks/packit"

--- a/build_test.go
+++ b/build_test.go
@@ -1,4 +1,4 @@
-package main_test
+package unicorn_test
 
 import (
 	"bytes"
@@ -8,7 +8,7 @@ import (
 
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/scribe"
-	main "github.com/paketo-community/unicorn"
+	"github.com/paketo-community/unicorn"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -40,7 +40,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 		logger := scribe.NewLogger(buffer)
 
-		build = main.Build(logger)
+		build = unicorn.Build(logger)
 	})
 
 	it.After(func() {
@@ -80,7 +80,5 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
 		Expect(buffer.String()).To(ContainSubstring("Writing start command"))
-
 	})
-
 }

--- a/detect.go
+++ b/detect.go
@@ -1,4 +1,4 @@
-package main
+package unicorn
 
 import (
 	"fmt"

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,4 +1,4 @@
-package main_test
+package unicorn_test
 
 import (
 	"errors"
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 
 	"github.com/paketo-buildpacks/packit"
-	main "github.com/paketo-community/unicorn"
+	"github.com/paketo-community/unicorn"
 	"github.com/paketo-community/unicorn/fakes"
 	"github.com/sclevine/spec"
 
@@ -38,7 +38,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		gemfileParser = &fakes.Parser{}
 
-		detect = main.Detect(gemfileParser)
+		detect = unicorn.Detect(gemfileParser)
 	})
 
 	it.After(func() {
@@ -59,19 +59,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Requires: []packit.BuildPlanRequirement{
 					{
 						Name: "gems",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: unicorn.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "bundler",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: unicorn.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "mri",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: unicorn.BuildPlanMetadata{
 							Launch: true,
 						},
 					},

--- a/gemfile_parser.go
+++ b/gemfile_parser.go
@@ -1,4 +1,4 @@
-package main
+package unicorn
 
 import (
 	"bufio"

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -1,14 +1,14 @@
-package main_test
+package unicorn_test
 
 import (
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/paketo-community/unicorn"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
-	main "github.com/paketo-community/unicorn"
 )
 
 func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
@@ -16,7 +16,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		path   string
-		parser main.GemfileParser
+		parser unicorn.GemfileParser
 	)
 
 	it.Before(func() {
@@ -26,7 +26,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 
 		path = file.Name()
 
-		parser = main.NewGemfileParser()
+		parser = unicorn.NewGemfileParser()
 	})
 
 	it.After(func() {

--- a/init_test.go
+++ b/init_test.go
@@ -1,4 +1,4 @@
-package main_test
+package unicorn_test
 
 import (
 	"testing"

--- a/run/main.go
+++ b/run/main.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/scribe"
+	"github.com/paketo-community/unicorn"
 )
 
 func main() {
-	parser := NewGemfileParser()
+	parser := unicorn.NewGemfileParser()
 	logger := scribe.NewLogger(os.Stdout)
 
-	detect := Detect(parser)
-	build := Build(logger)
-
-	packit.Run(detect, build)
+	packit.Run(
+		unicorn.Detect(parser),
+		unicorn.Build(logger),
+	)
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,6 +8,28 @@ readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
 function main() {
     mkdir -p "${BUILDPACKDIR}/bin"
 
+    if [[ -f "${BUILDPACKDIR}/run/main.go" ]]; then
+        pushd "${BUILDPACKDIR}/bin" > /dev/null || return
+            printf "%s" "Building run..."
+
+            GOOS=linux \
+              go build \
+                -ldflags="-s -w" \
+                -o "run" \
+                  "${BUILDPACKDIR}/run"
+
+            echo "Success!"
+
+            for name in detect build; do
+              printf "%s" "Linking ${name}..."
+
+              ln -sf "run" "${name}"
+
+              echo "Success!"
+            done
+        popd > /dev/null || return
+    fi
+
     if [[ -f "${BUILDPACKDIR}/main.go" ]]; then
         pushd "${BUILDPACKDIR}/bin" > /dev/null || return
             printf "%s" "Building run..."


### PR DESCRIPTION
This ensures that we don't have issues with importing `main` if that needs to happen.